### PR TITLE
Add top terms per cluster attribute to IterativeDocumentClustering

### DIFF
--- a/backoffice/analytics/clustering.py
+++ b/backoffice/analytics/clustering.py
@@ -13,7 +13,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.cluster import KMeans
 from sklearn.manifold import MDS
 from sklearn.metrics.pairwise import cosine_similarity
-from utils import tokenize_and_remove_stop_words, tokenize_and_stem, \
+from analytics.utils import tokenize_and_remove_stop_words, tokenize_and_stem,\
                   download_stop_words
 
 


### PR DESCRIPTION
Implemented **_top terms per cluster_** feature as an attribute and not as a method because it need to be calculated while doing the clustering iterations and not after the whole clustering process has ended.