### PR TITLE
Create dataset and attributes in an only endpoint

### DIFF
--- a/backoffice/backoffice/urls.py
+++ b/backoffice/backoffice/urls.py
@@ -26,7 +26,6 @@ router = routers.DefaultRouter()
 router.register(r'users', views.UserViewSet)
 router.register(r'projects', views.ProjectViewSet)
 router.register(r'attributes', views.AttributeViewSet)
-router.register(r'datasets', views.DatasetViewSet)
 router.register(r'visualizations', views.VisualizationViewSet)
 router.register(r'visualizationType', views.VisualizationTypeViewSet)
 router.register(r'ownership', views.OwnershipViewSet)
@@ -40,6 +39,8 @@ schema_view = get_swagger_view(title='Backoffice API')
 urlpatterns = [
     url(r'^api/$', schema_view),
     url(r'^api/', include(router.urls)),
+    # ex: /api/datasets/
+    url(r'^api/datasets/$', views.DatasetList.as_view()),
     # ex: /api/analysis/sentiment-analysis/
     url(r'^api/analysis/sentiment-analysis/$', views.SentimentAnalysisList.as_view()),
     # ex: /api/analysis/doc-clustering/

--- a/backoffice/backoffice/urls.py
+++ b/backoffice/backoffice/urls.py
@@ -41,6 +41,8 @@ urlpatterns = [
     url(r'^api/', include(router.urls)),
     # ex: /api/datasets/
     url(r'^api/datasets/$', views.DatasetList.as_view()),
+    # ex: /api/datasets/dataset_id
+    url(r'^api/datasets/(?P<pk>[0-9]+)/$', views.DatasetDetail.as_view()),
     # ex: /api/analysis/sentiment-analysis/
     url(r'^api/analysis/sentiment-analysis/$', views.SentimentAnalysisList.as_view()),
     # ex: /api/analysis/doc-clustering/

--- a/backoffice/core/models.py
+++ b/backoffice/core/models.py
@@ -58,7 +58,7 @@ class AttributeType(models.Model):
 class Attribute(models.Model):
     name = models.CharField(max_length=50)
     included_in_analysis = models.BooleanField()
-    dataset = models.ForeignKey(Dataset, on_delete=models.CASCADE)
+    dataset = models.ForeignKey(Dataset, related_name='attributes', on_delete=models.CASCADE)
     attribute_type = models.ForeignKey(AttributeType)
 
 

--- a/backoffice/core/serializers.py
+++ b/backoffice/core/serializers.py
@@ -21,9 +21,11 @@ class AttributeSerializer(serializers.ModelSerializer):
 
 
 class DatasetSerializer(serializers.ModelSerializer):
+    attributes = AttributeSerializer(many=True, read_only=True)
+
     class Meta:
         model = Dataset
-        fields = '__all__'
+        fields = ('id','name','file','creation_status','attributes')
 
 
 class ProjectSerializer(serializers.ModelSerializer):

--- a/backoffice/core/views.py
+++ b/backoffice/core/views.py
@@ -620,6 +620,25 @@ class DatasetList(APIView):
             return resp
 
 
+class DatasetDetail(APIView):
+    def get(self, request, pk, format=None):
+        """
+        Retrieve a dataset instance
+        """
+        dataset = get_object(Dataset,pk)
+        serializer = DatasetSerializer(dataset)
+        return Response(serializer.data)
+
+    def delete(self, request, pk, format=None):
+        """
+        Delete a dataset instance
+        """
+        dataset = get_object(Dataset, pk)
+        dataset.file.delete()
+        dataset.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
 # ---
 # API ViewSet Classes
 # ---

--- a/backoffice/core/views.py
+++ b/backoffice/core/views.py
@@ -574,6 +574,52 @@ class DocumentClusteringDetail(AnalysisObjectDetail): pass
 class ConceptExtractionDetail(AnalysisObjectDetail): pass
 
 
+class DatasetList(APIView):
+    def get(self, request, format=None):
+        """
+        List all datasets
+        """
+        try:
+            datasets = Dataset.objects.all()
+            serializer = DatasetSerializer(datasets, many=True)
+            return Response(serializer.data)
+        except Exception as ex:
+            resp = Response(status=status.HTTP_400_BAD_REQUEST)
+            resp.content = ex
+            return resp
+
+    def post(self, request, format=None):
+        """
+        Create a new dataset and his associated attributes
+        """
+        # Get request data
+        dataset = {
+            'name': request.data['name'], 'file': request.data['file']
+        }            
+        attributes = json.loads(request.data['attributes'])
+        
+        try: 
+            with transaction.atomic():
+                # Save dataset
+                datasetSerializer = DatasetSerializer(data=dataset)
+                datasetSerializer.is_valid()
+                datasetSerializer.save()
+                
+                # Save attributes
+                for attr in attributes:
+                    dataset_id = Dataset.objects.latest('id').id
+                    attr.update({'dataset':dataset_id})
+                    attributeSerializer = AttributeSerializer(data=attr)
+                    attributeSerializer.is_valid()
+                    attributeSerializer.save()
+                
+                return Response(datasetSerializer.data, status=status.HTTP_201_CREATED)
+        except Exception as ex:
+            resp = Response(status=status.HTTP_400_BAD_REQUEST)
+            resp.content = ex
+            return resp
+
+
 # ---
 # API ViewSet Classes
 # ---
@@ -622,12 +668,6 @@ class ProjectViewSet(viewsets.ModelViewSet):
 class AttributeViewSet(viewsets.ModelViewSet):
     queryset = Attribute.objects.all()
     serializer_class = AttributeSerializer
-
-
-@permission_classes((CorePermissions, ))
-class DatasetViewSet(viewsets.ModelViewSet):
-    queryset = Dataset.objects.all()
-    serializer_class = DatasetSerializer
 
 
 @permission_classes((CorePermissionsOrAnonReadOnly, ))


### PR DESCRIPTION
Now, the POST of a dataset operation has the following parameters:
name: string
file : FILE
attributes: list of dictionaries 
ex: [{ "name": "text", "included_in_analysis": true, "attribute_type": 1 }, ... ]

The GET dataset operation retrieves all the related attributes too.